### PR TITLE
Use /vaults/{vaultId} API for origin.

### DIFF
--- a/frontend/src/common/universalVaultFormat.ts
+++ b/frontend/src/common/universalVaultFormat.ts
@@ -346,7 +346,7 @@ export class VaultMetadata {
       cty: 'json',
       crit: ['uvf.spec.version'],
       'uvf.spec.version': 1,
-      'cloud.katta.origin': `${apiURL}/vaults/${vault.id}/uvf/vault.uvf`, // single source of truth for this vault
+      'cloud.katta.origin': `${apiURL}/vaults/${vault.id}`, // single source of truth for this vault
       jku: 'jwks.json', // URL relative to cloud.katta.origin
     };
     const jwe = await JWE.build(this.payload(), protectedHeader).encrypt(Recipient.a256kw('org.cryptomator.hub.memberkey', memberKey.key), Recipient.ecdhEs(recoveryKeyID, recoveryKey.publicKey));


### PR DESCRIPTION
Server-side counterpart for: https://github.com/shift7-ch/katta-clientlib/issues/236