### PR TITLE
Show S3 pre-flight errors on the create vault details step

### DIFF
--- a/frontend/src/components/CreateVault.vue
+++ b/frontend/src/components/CreateVault.vue
@@ -281,6 +281,10 @@
                   <p v-else-if="(onCreateError instanceof StorageProfileError )">
                     {{ t('CreateVaultS3.error.invalidStorageProfileConfiguration', '') }}: {{ onCreateError.message }}
                   </p>
+                  <template v-else-if="(onCreateError instanceof StorageBackendError)">
+                    <p>{{ onCreateError.message }}</p>
+                    <pre v-if="onCreateError.codeHint" class="mt-2 text-left text-xs text-gray-900 max-h-64 overflow-auto whitespace-pre-wrap break-words bg-white rounded p-2 ring-1 ring-inset ring-gray-200">{{ onCreateError.codeHint }}</pre>
+                  </template>
                   <!-- // \ end katta extension -->
                   <!-- // / start katta modification -->
                   <p v-else-if="(onCreateError instanceof DecodeUvfRecoveryKeyError || onCreateError instanceof DecodeVf8RecoveryKeyError)">
@@ -619,7 +623,7 @@ import {
 import { ChevronUpDownIcon } from '@heroicons/vue/24/outline';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/solid';
 import { STSClient,AssumeRoleWithWebIdentityCommand } from '@aws-sdk/client-sts';
-import { S3Client, PutObjectCommand, ListObjectsV2Command, GetBucketLocationCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, ListObjectsV2Command, GetBucketLocationCommand, S3ServiceException } from '@aws-sdk/client-s3';
 import authPromise from '../common/auth';
 import { AxiosError } from 'axios';
 import { base64urlnopad } from '@scure/base';
@@ -744,11 +748,10 @@ const automaticAccessGrant = ref<boolean>(true);
 const onOpenBookmarkError = ref<Error | null>(null);
 const onUploadTemplateError = ref<Error | null>(null);
 
-class ErrorWithCodeHint extends Error {
+class StorageBackendError extends Error {
 
-  constructor(public message: string, public codehint: string) {
+  constructor(message: string, public codeHint?: string) {
     super(message);
-    this.codehint = codehint;
   }
 
 }
@@ -953,32 +956,17 @@ async function validateVaultDetails() {
         const responseListObjects = await client.send(commandListObjects);
         console.log(responseListObjects);
         if (responseListObjects.KeyCount != 0){
-          onCreateError.value = new Error(t('CreateVaultS3.error.bucketNotEmpty'));
+          onCreateError.value = new StorageBackendError(t('CreateVaultS3.error.bucketNotEmpty'));
           return;
         }
       } catch (error) {
         console.log(error);
         // TODO review can we improve whether this is a CORS problem? FF message is "NetworkError when attempting to fetch resource", Safari "Load failed".
         if (error instanceof TypeError){
-          onCreateError.value = new ErrorWithCodeHint(error.message + '. ' + t('CreateVaultS3.error.invalidCORS'), `
-          aws s3api put-bucket-cors --endpoint-url ${endpoint} --bucket ${effectiveBucketName.value} --cors-configuration file://cors.json
-
-          cors.json:
-          {
-            "CORSRules": [
-              {
-                "AllowedHeaders": ["*"],
-                "AllowedMethods": ["GET", "PUT"],
-                "AllowedOrigins": ["${document.baseURI}"],
-                "ExposeHeaders": ["ETag"],
-                "MaxAgeSeconds": 3600
-              }
-            ]
-          }
-          `);
+          onCreateError.value = new StorageBackendError(t('CreateVaultS3.error.invalidCORS', [error.message]), corsConfigurationHint(endpoint, effectiveBucketName.value));
         } else {
-          console.error('Uploading template failed.', error);
-          onUploadTemplateError.value = error instanceof Error ? error : new Error('Unknown Error');
+          console.error('Checking the bucket failed.', error);
+          onCreateError.value = new StorageBackendError(bucketAccessErrorMessage(error));
         }
         return;
       }
@@ -1003,6 +991,42 @@ function isS3ErrorWithRegion(error: unknown): error is { Code: string; Region: s
     && 'Region' in error
   );
 }
+
+// / start katta extension
+function bucketAccessErrorMessage(error: unknown): string {
+  // The AWS SDK exposes the S3 error code as the exception's name, for both modeled and unmodeled errors.
+  switch (error instanceof S3ServiceException ? error.name : undefined) {
+    case 'InvalidAccessKeyId':
+      return t('CreateVaultS3.error.invalidAccessKeyId');
+    case 'SignatureDoesNotMatch':
+      return t('CreateVaultS3.error.signatureDoesNotMatch');
+    case 'NoSuchBucket':
+      return t('CreateVaultS3.error.noSuchBucket');
+    case 'AccessDenied':
+      return t('CreateVaultS3.error.accessDenied');
+    default:
+      return t('CreateVaultS3.error.bucketAccessFailed', [error instanceof Error ? error.message : String(error)]);
+  }
+}
+
+function corsConfigurationHint(endpoint: string, bucket: string): string {
+  // S3 matches AllowedOrigins against the browser's Origin header, which carries no path.
+  return `aws s3api put-bucket-cors --endpoint-url ${endpoint} --bucket ${bucket} --cors-configuration file://cors.json
+
+cors.json:
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "PUT"],
+      "AllowedOrigins": ["${location.origin}"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}`;
+}
+// \ end katta extension
 
 function validateAutomaticAccessGrant() {
   onCreateError.value = undefined;

--- a/frontend/src/components/CreateVault.vue
+++ b/frontend/src/components/CreateVault.vue
@@ -623,11 +623,11 @@ import {
 import { ChevronUpDownIcon } from '@heroicons/vue/24/outline';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/solid';
 import { STSClient,AssumeRoleWithWebIdentityCommand } from '@aws-sdk/client-sts';
-import { S3Client, PutObjectCommand, ListObjectsV2Command, GetBucketLocationCommand, S3ServiceException } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, GetBucketLocationCommand, S3ServiceException } from '@aws-sdk/client-s3';
 import authPromise from '../common/auth';
 import { AxiosError } from 'axios';
 import { base64urlnopad } from '@scure/base';
-import { isAwsHostname } from '../../src/common/katta';
+import { isAwsHostname } from '../common/katta';
 // \ end katta extension
 
 enum State {
@@ -955,7 +955,7 @@ async function validateVaultDetails() {
         });
         const responseListObjects = await client.send(commandListObjects);
         console.log(responseListObjects);
-        if (responseListObjects.KeyCount != 0){
+        if (!isBucketEmpty(responseListObjects)){
           onCreateError.value = new StorageBackendError(t('CreateVaultS3.error.bucketNotEmpty'));
           return;
         }
@@ -1007,6 +1007,12 @@ function bucketAccessErrorMessage(error: unknown): string {
     default:
       return t('CreateVaultS3.error.bucketAccessFailed', [error instanceof Error ? error.message : String(error)]);
   }
+}
+
+// KeyCount is optional and omitted by some S3-compatible backends, so Contents is the primary signal.
+// KeyCount is still checked so a response asserting a non-zero count is never treated as an empty bucket.
+function isBucketEmpty(response: ListObjectsV2CommandOutput): boolean {
+  return (response.Contents?.length ?? 0) === 0 && (response.KeyCount ?? 0) === 0;
 }
 
 function corsConfigurationHint(endpoint: string, bucket: string): string {
@@ -1406,8 +1412,8 @@ async function uploadVaultTemplate() {
     });
     const responseListObjects = await client.send(commandListObjects);
     console.log(responseListObjects);
-    if (responseListObjects.KeyCount != 0){
-      throw new Error('Bucket not empty, cannot upload template. Empty the bucket manually and re-try.');
+    if (!isBucketEmpty(responseListObjects)){
+      throw new Error(t('CreateVaultS3.error.bucketNotEmpty'));
     }
     if (!uvfVault.value){
       throw new Error('Invalid state');

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -342,6 +342,12 @@
   "CreateVaultS3.success.description": "Katta auf dem Computer benützen, um den Tresor zu öffnen.",
   "CreateVaultS3.success.open": "Tresore in Katta öffnen",
   "CreateVaultS3.error.uploadTemplateFailed": "Hochladen Tresorvorlage nach S3-Bucket fehlgeschlagen.",
+  "CreateVaultS3.error.invalidAccessKeyId": "Der Benutzername ist diesem Speicherbereich nicht bekannt. Prüfe den Benutzernamen und versuche es erneut.",
+  "CreateVaultS3.error.signatureDoesNotMatch": "Das Passwort passt nicht zum Benutzernamen. Prüfe das Passwort und versuche es erneut.",
+  "CreateVaultS3.error.noSuchBucket": "Der Bucket existiert in diesem Speicherbereich nicht. Prüfe den Bucket-Namen und versuche es erneut.",
+  "CreateVaultS3.error.accessDenied": "Der Benutzername darf nicht auf diesen Bucket zugreifen. Prüfe die Bucket-Berechtigungen und versuche es erneut.",
+  "CreateVaultS3.error.bucketAccessFailed": "Auf den Bucket konnte nicht zugegriffen werden: {0}",
+  "CreateVaultS3.error.invalidCORS": "{0}. Prüfe die CORS-Einstellungen des Buckets.",
 
 
   "nav.profile.storageprofiles": "Admin Tresor-Speicherbereiche",

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -342,6 +342,7 @@
   "CreateVaultS3.success.description": "Katta auf dem Computer benützen, um den Tresor zu öffnen.",
   "CreateVaultS3.success.open": "Tresore in Katta öffnen",
   "CreateVaultS3.error.uploadTemplateFailed": "Hochladen Tresorvorlage nach S3-Bucket fehlgeschlagen.",
+  "CreateVaultS3.error.bucketNotEmpty": "Bucket nicht leer, Tresorvorlage kann nicht hochgeladen werden. Leere den Bucket manuell und versuche es erneut.",
   "CreateVaultS3.error.invalidAccessKeyId": "Der Benutzername ist diesem Speicherbereich nicht bekannt. Prüfe den Benutzernamen und versuche es erneut.",
   "CreateVaultS3.error.signatureDoesNotMatch": "Das Passwort passt nicht zum Benutzernamen. Prüfe das Passwort und versuche es erneut.",
   "CreateVaultS3.error.noSuchBucket": "Der Bucket existiert in diesem Speicherbereich nicht. Prüfe den Bucket-Namen und versuche es erneut.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -684,7 +684,12 @@
   "CreateVaultS3.error.missingSecretKey": "Enter the password and re-try.",
   "CreateVaultS3.error.missingBucket": "Enter the bucket name and re-try.",
   "CreateVaultS3.error.bucketNotEmpty": "Bucket not empty, cannot upload template. Empty the bucket manually and re-try.",
-  "CreateVaultS3.error.invalidCORS": "Check your bucket CORS settings.",
+  "CreateVaultS3.error.invalidAccessKeyId": "The username is not known to this storage location. Check the username and re-try.",
+  "CreateVaultS3.error.signatureDoesNotMatch": "The password does not match the username. Check the password and re-try.",
+  "CreateVaultS3.error.noSuchBucket": "The bucket does not exist at this storage location. Check the bucket name and re-try.",
+  "CreateVaultS3.error.accessDenied": "The username is not allowed to access this bucket. Check the bucket permissions and re-try.",
+  "CreateVaultS3.error.bucketAccessFailed": "The bucket could not be accessed: {0}",
+  "CreateVaultS3.error.invalidCORS": "{0}. Check your bucket CORS settings.",
 
   "nav.profile.storageprofiles": "Admin Storage Locations",
   "storageProfileList.title": "Storage Locations",


### PR DESCRIPTION
Closes #155. Closes #177.

The bucket pre-flight in `validateVaultDetails()` wrote its failure to `onUploadTemplateError`, which only renders in the `Finished` block, so the details step showed nothing at all. Clicking Next with bad credentials left the form sitting there with the reason only in the browser console.

The pre-flight now reports through `onCreateError` as a `StorageBackendError` carrying an optional remediation hint. The step renders the message, and the hint in a scrollable block when there is one.

The CORS branch already built an `aws s3api put-bucket-cors` snippet with the bucket and origin filled in, but nothing rendered it, so first-time setup gave no instruction on configuring cross-origin requests. It shows now, with two corrections: `AllowedOrigins` uses `location.origin`, since S3 matches against the Origin header and that carries no path (`document.baseURI` included the deployment path and would never match), and the snippet no longer inherits the indentation of its source position.

S3 failures also get a message per error code (`InvalidAccessKeyId`, `SignatureDoesNotMatch`, `NoSuchBucket`, `AccessDenied`) taken from `S3ServiceException.name`, instead of one catch-all. Those only reach the browser when the bucket already has CORS configured. Without it every S3 error response collapses into an opaque `TypeError` and the CORS branch handles it, which makes that branch the common case rather than the exception.

`onUploadTemplateError` keeps its original job, the actual template upload on the Finished step.

## Not in this PR

- `uploadVaultTemplate()` does not use these helpers and throws a hardcoded English string. It is the only path for non-AWS endpoints, since the pre-flight is gated on `isAwsHostname()`.
- A failed template upload still lands on the success screen.
- de-DE is missing the older `CreateVaultS3.error.*` keys that render in the same panel.
