### PR TITLE
jspecify: explicitly mark `@Nullable` fields

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.oidc.OidcConfigurationMetadata;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -117,10 +118,10 @@ public class ConfigResource {
 							@JsonProperty("licenseApiUrl") String licenseApiUrl,
 							@JsonProperty("licenseSetupRequired") boolean licenseSetupRequired
                             // / start katta extension
-            , @JsonProperty("keycloakClientIdCryptomatorVaults") String keycloakClientIdCryptomatorVaults
-            , @JsonProperty("uuid") String uuid
-            , @JsonProperty("desktopDownloadUrlMac") String desktopDownloadUrlMac
-            , @JsonProperty("desktopDownloadUrlWin") String desktopDownloadUrlWin
+            , @JsonProperty("keycloakClientIdCryptomatorVaults") @NotNull String keycloakClientIdCryptomatorVaults
+            , @JsonProperty("uuid") @NotNull String uuid
+            , @JsonProperty("desktopDownloadUrlMac") @NotNull String desktopDownloadUrlMac
+            , @JsonProperty("desktopDownloadUrlWin") @NotNull String desktopDownloadUrlWin
                             // \ end katta extension
     ) {}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -722,8 +722,8 @@ public class VaultResource {
 	public Response createOrUpdate(
 			@PathParam("vaultId") UUID vaultId, @Valid @NotNull VaultDto vaultDto
 			// / start katta extension
-			, @QueryParam("minio") Boolean minio
-			, @QueryParam("aws") Boolean aws
+			, @Nullable @QueryParam("minio") Boolean minio
+			, @Nullable @QueryParam("aws") Boolean aws
 			// \ end katta extension
 	) {
 		User currentUser = userRepo.findById(jwt.getSubject());

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -713,8 +713,8 @@ public class VaultResource {
 	@Operation(summary = "creates or updates a vault",
 			description = "Creates or updates a vault with the given vault id. The creationTime in the vaultDto is always ignored. The archived field is always ignored (use the dedicated endpoint). On creation, the current server time is used. On update, only the name and description fields are considered.")
 	// / start katta extension
-	@Parameter(name = "minio", in = ParameterIn.QUERY, description = "whether configuration for STS MinIO needs to be synched to Keycloak (defaults to false)")
-	@Parameter(name = "aws", in = ParameterIn.QUERY, description = "whether configuration for STS MinIO needs to be synched to AWS (defaults to false)")
+	@Parameter(name = "minio", in = ParameterIn.QUERY, description = "controls the MinIO STS protocol mapper in Keycloak: true creates/updates it, false deletes it, unset leaves it untouched")
+	@Parameter(name = "aws", in = ParameterIn.QUERY, description = "controls the AWS STS protocol mapper in Keycloak: true creates/updates it, false deletes it, unset leaves it untouched")
 	// \ end katta extension
 	@APIResponse(responseCode = "200", description = "existing vault updated")
 	@APIResponse(responseCode = "201", description = "new vault created")

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/CreateS3STSBucketDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/CreateS3STSBucketDto.java
@@ -1,29 +1,29 @@
 package org.cryptomator.hub.api.katta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jspecify.annotations.Nullable;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
 public record CreateS3STSBucketDto(
 		@JsonProperty("vaultId")
-		String vaultId,
+		@NotNull String vaultId,
 		@JsonProperty("storageConfigId")
-		UUID storageConfigId,
+		@NotNull UUID storageConfigId,
 		@JsonProperty("vaultUvf")
-		String vaultUvf,
+		@NotNull String vaultUvf,
 		@JsonProperty("dirUvf")
-		String dirUvf,
+		@NotNull String dirUvf,
 		@JsonProperty("rootDirHash")
-		String rootDirHash,
+		@NotNull String rootDirHash,
 		@JsonProperty("awsAccessKey")
-		String awsAccessKey,
+		@NotNull String awsAccessKey,
 		@JsonProperty("awsSecretKey")
-		String awsSecretKey,
+		@NotNull String awsSecretKey,
 		@JsonProperty("sessionToken")
-		String sessionToken,
+		@NotNull String sessionToken,
 		@JsonProperty("region")
-		@Nullable String region
+		@NotNull String region
 ) {
 
 	@Override

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/CreateS3STSBucketDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/CreateS3STSBucketDto.java
@@ -1,6 +1,7 @@
 package org.cryptomator.hub.api.katta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -22,8 +23,22 @@ public record CreateS3STSBucketDto(
 		@JsonProperty("sessionToken")
 		String sessionToken,
 		@JsonProperty("region")
-		String region
+		@Nullable String region
 ) {
 
+	@Override
+	public String toString() {
+		return "CreateS3STSBucketDto{" +
+				"vaultId='" + vaultId + '\'' +
+				", storageConfigId=" + storageConfigId +
+				", vaultUvf='" + vaultUvf + '\'' +
+				", dirUvf='" + dirUvf + '\'' +
+				", rootDirHash='" + rootDirHash + '\'' +
+				", sessionToken='" + sessionToken + '\'' +
+				", region='" + region + '\'' +
+				", awsAccessKey=***" +
+				", awsSecretKey=***" +
+				'}';
+	}
 }
 

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileDto.java
@@ -10,6 +10,7 @@ import org.cryptomator.hub.entities.katta.StorageProfileS3STS;
 import org.cryptomator.hub.entities.katta.StorageProfileS3Static;
 import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -40,14 +41,14 @@ public abstract sealed class StorageProfileDto permits StorageProfileS3StaticDto
 	}
 
 	// id is assigned by the server on creation; clients must not supply it (any supplied value is ignored).
-	private final UUID id;
+	private final @Nullable UUID id;
 	@NotNull
 	private final String name;
 	@NotNull
 	private final Protocol protocol;
 	private final boolean archived;
 
-	protected StorageProfileDto(UUID id, String name, Protocol protocol, boolean archived) {
+	protected StorageProfileDto(@Nullable UUID id, String name, Protocol protocol, boolean archived) {
 		this.id = id;
 		this.name = name;
 		this.protocol = protocol;
@@ -56,7 +57,7 @@ public abstract sealed class StorageProfileDto permits StorageProfileS3StaticDto
 
 	@JsonProperty("id")
 	@Schema(description = "Technical identifier for a storage profile, assigned by the server on creation (read-only). Clients use this as vendor in profile and provider in vault bookmark.", readOnly = true)
-	public UUID getId() {
+	public @Nullable UUID getId() {
 		return id;
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileDto.java
@@ -56,7 +56,7 @@ public abstract sealed class StorageProfileDto permits StorageProfileS3StaticDto
 	}
 
 	@JsonProperty("id")
-	@Schema(description = "Technical identifier for a storage profile, assigned by the server on creation (read-only). Clients use this as vendor in profile and provider in vault bookmark.", readOnly = true)
+	@Schema(description = "Technical identifier for a storage profile, assigned by the server on creation (read-only). Clients use this as vendor in profile and provider in vault bookmark.", required = true, readOnly = true)
 	public @Nullable UUID getId() {
 		return id;
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileResource.java
@@ -1,6 +1,5 @@
 package org.cryptomator.hub.api.katta;
 
-import jakarta.annotation.Nullable;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -24,6 +23,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.hibernate.exception.ConstraintViolationException;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.List;
@@ -95,7 +95,7 @@ public class StorageProfileResource {
 	@Operation(summary = "set the archived state of a storage profile", description = "Archives (archived=true) or unarchives (archived=false) the storage profile. While archived, no new vaults can be created for this profile.")
 	@APIResponse(responseCode = "204", description = "archived state updated")
 	@APIResponse(responseCode = "403", description = "not an admin")
-	public Response archive(@PathParam("profileId") UUID profileId, @NotNull @FormParam("archived") final boolean archived) {
+	public Response archive(@PathParam("profileId") UUID profileId, @NotNull @FormParam("archived") final Boolean archived) {
 		final StorageProfile entity = storageProfileRepo.findByIdOptional(profileId).orElseThrow(NotFoundException::new);
 		storageProfileRepo.persistAndFlush(entity.setArchived(archived));
 		return Response.status(Response.Status.NO_CONTENT).build();

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3STSDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3STSDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import org.cryptomator.hub.entities.katta.S3StorageClass;
 import org.cryptomator.hub.entities.katta.StorageProfileS3STS;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,25 +23,25 @@ public final class StorageProfileS3STSDto extends StorageProfileS3StaticDto {
 	private final String stsRoleCreateBucketClient;
 	@NotNull
 	private final String stsRoleCreateBucketHub;
-	private final String stsEndpoint;
+	private final @Nullable String stsEndpoint;
 
 	//----------------------------------------------------------------------
 	// (3b) STS client profile custom properties
 	//----------------------------------------------------------------------
 	@NotNull
 	private final String stsRoleAccessBucketAssumeRoleWithWebIdentity;
-	private final String stsRoleAccessBucketAssumeRoleTaggedSession;
-	private final Integer stsDurationSeconds;
+	private final @Nullable String stsRoleAccessBucketAssumeRoleTaggedSession;
+	private final @Nullable Integer stsDurationSeconds;
 	@NotNull
 	private final String stsSessionTag;
 
 	@JsonCreator
 	public StorageProfileS3STSDto(
-			@JsonProperty("id") UUID id,
+			@JsonProperty("id") @Nullable UUID id,
 			@JsonProperty("name") String name,
 			@JsonProperty("protocol") Protocol protocol,
 			@JsonProperty("archived") boolean archived,
-			@JsonProperty("endpoint") String endpoint,
+			@JsonProperty("endpoint") @Nullable String endpoint,
 			@JsonProperty("pathStyleAccessEnabled") boolean pathStyleAccessEnabled,
 			@JsonProperty("storageClass") S3StorageClass storageClass,
 			@JsonProperty("region") String region,
@@ -48,10 +49,10 @@ public final class StorageProfileS3STSDto extends StorageProfileS3StaticDto {
 			@JsonProperty("bucketPrefix") String bucketPrefix,
 			@JsonProperty("stsRoleCreateBucketClient") String stsRoleCreateBucketClient,
 			@JsonProperty("stsRoleCreateBucketHub") String stsRoleCreateBucketHub,
-			@JsonProperty("stsEndpoint") String stsEndpoint,
+			@JsonProperty("stsEndpoint") @Nullable String stsEndpoint,
 			@JsonProperty("stsRoleAccessBucketAssumeRoleWithWebIdentity") String stsRoleAccessBucketAssumeRoleWithWebIdentity,
-			@JsonProperty("stsRoleAccessBucketAssumeRoleTaggedSession") String stsRoleAccessBucketAssumeRoleTaggedSession,
-			@JsonProperty("stsDurationSeconds") Integer stsDurationSeconds,
+			@JsonProperty("stsRoleAccessBucketAssumeRoleTaggedSession") @Nullable String stsRoleAccessBucketAssumeRoleTaggedSession,
+			@JsonProperty("stsDurationSeconds") @Nullable Integer stsDurationSeconds,
 			@JsonProperty("stsSessionTag") String stsSessionTag) {
 		super(id, name, protocol, archived, endpoint, pathStyleAccessEnabled, storageClass, region, regions, bucketPrefix);
 		this.stsRoleCreateBucketClient = stsRoleCreateBucketClient;
@@ -77,7 +78,7 @@ public final class StorageProfileS3STSDto extends StorageProfileS3StaticDto {
 
 	@JsonProperty("stsEndpoint")
 	@Schema(description = "STS endpoint to use for AssumeRoleWithWebIdentity and AssumeRole for getting a temporary access token passed to the storage. Defaults to AWS SDK default.", nullable = true)
-	public String getStsEndpoint() {
+	public @Nullable String getStsEndpoint() {
 		return stsEndpoint;
 	}
 
@@ -89,13 +90,13 @@ public final class StorageProfileS3STSDto extends StorageProfileS3StaticDto {
 
 	@JsonProperty("stsRoleAccessBucketAssumeRoleTaggedSession")
 	@Schema(description = "roleArn to assume for STS AssumeRole in role chaining (AWS only, not MinIO)", examples = "arn:aws:iam::930717317329:role/katta_chain_02", nullable = true)
-	public String getStsRoleAccessBucketAssumeRoleTaggedSession() {
+	public @Nullable String getStsRoleAccessBucketAssumeRoleTaggedSession() {
 		return stsRoleAccessBucketAssumeRoleTaggedSession;
 	}
 
 	@JsonProperty("stsDurationSeconds")
 	@Schema(description = "Token lifetime for STS tokens assumed. Defaults to AWS/MinIO defaults", nullable = true)
-	public Integer getStsDurationSeconds() {
+	public @Nullable Integer getStsDurationSeconds() {
 		return stsDurationSeconds;
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3STSDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3STSDto.java
@@ -116,7 +116,7 @@ public final class StorageProfileS3STSDto extends StorageProfileS3StaticDto {
 				entity.pathStyleAccessEnabled,
 				entity.storageClass,
 				entity.region,
-				entity.regions == null ? List.of() : entity.regions,
+				entity.regions,
 				entity.bucketPrefix,
 				entity.stsRoleCreateBucketClient,
 				entity.stsRoleCreateBucketHub,

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3StaticDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3StaticDto.java
@@ -81,7 +81,7 @@ public sealed class StorageProfileS3StaticDto extends StorageProfileDto permits 
 	}
 
 	@JsonProperty("regions")
-	@Schema(description = "List of selectable regions in the frontend/client to create bucket in. Defaults to full list from AWS SDK.", required = true)
+	@Schema(description = "List of selectable regions in the frontend/client to create bucket in.", required = true)
 	public List<String> getRegions() {
 		return regions;
 	}
@@ -93,7 +93,7 @@ public sealed class StorageProfileS3StaticDto extends StorageProfileDto permits 
 	}
 
 	static StorageProfileS3StaticDto fromEntity(StorageProfileS3Static entity) {
-		return new StorageProfileS3StaticDto(entity.id, entity.name, Protocol.S3_STATIC, entity.archived, entity.endpoint, entity.pathStyleAccessEnabled, entity.storageClass, entity.region, entity.regions == null ? List.of() : entity.regions, entity.bucketPrefix);
+		return new StorageProfileS3StaticDto(entity.id, entity.name, Protocol.S3_STATIC, entity.archived, entity.endpoint, entity.pathStyleAccessEnabled, entity.storageClass, entity.region, entity.regions, entity.bucketPrefix);
 	}
 
 	@Override

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3StaticDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageProfileS3StaticDto.java
@@ -7,6 +7,7 @@ import org.cryptomator.hub.entities.katta.S3StorageClass;
 import org.cryptomator.hub.entities.katta.StorageProfileS3Static;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.validator.constraints.URL;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
@@ -23,7 +24,7 @@ public sealed class StorageProfileS3StaticDto extends StorageProfileDto permits 
 	//======================================================================
 
 	@URL
-	private final String endpoint;
+	private final @Nullable String endpoint;
 	private final boolean pathStyleAccessEnabled;
 	@NotNull
 	private final S3StorageClass storageClass;
@@ -36,11 +37,11 @@ public sealed class StorageProfileS3StaticDto extends StorageProfileDto permits 
 
 	@JsonCreator
 	public StorageProfileS3StaticDto(
-			@JsonProperty("id") UUID id,
+			@JsonProperty("id") @Nullable UUID id,
 			@JsonProperty("name") String name,
 			@JsonProperty("protocol") Protocol protocol,
 			@JsonProperty("archived") boolean archived,
-			@JsonProperty("endpoint") String endpoint,
+			@JsonProperty("endpoint") @Nullable String endpoint,
 			@JsonProperty("pathStyleAccessEnabled") boolean pathStyleAccessEnabled,
 			@JsonProperty("storageClass") S3StorageClass storageClass,
 			@JsonProperty("region") String region,
@@ -57,7 +58,7 @@ public sealed class StorageProfileS3StaticDto extends StorageProfileDto permits 
 
 	@JsonProperty("endpoint")
 	@Schema(description = "Full S3 endpoint URL for template upload/bucket creation. If unset, defaults to AWS SDK defaults.", examples = "https://s3-us-gov-west-1.amazonaws.com", nullable = true)
-	public String getEndpoint() {
+	public @Nullable String getEndpoint() {
 		return endpoint;
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/StorageResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/StorageResource.java
@@ -3,6 +3,8 @@ package org.cryptomator.hub.api.katta;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -15,14 +17,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.cryptomator.hub.api.GoneException;
 import org.cryptomator.hub.api.katta.storage.S3StorageHelper;
-import org.cryptomator.hub.entities.Group;
-import org.cryptomator.hub.entities.User;
-import org.cryptomator.hub.entities.Vault;
 import org.cryptomator.hub.entities.katta.AccessTokenResponse;
 import org.cryptomator.hub.entities.katta.StorageProfile;
 import org.cryptomator.hub.entities.katta.StorageProfileS3STS;
-import org.cryptomator.hub.entities.katta.StorageProfileS3Static;
-import org.cryptomator.hub.katta.KeycloakCryptomatorVaultsHelper;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -30,10 +27,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
-import java.util.Map;
 import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 
 @Path("/storage")
@@ -63,7 +57,7 @@ public class StorageResource {
 	@APIResponse(responseCode = "400", description = "Could not create bucket")
 	@APIResponse(responseCode = "409", description = "Bucket with this name already exists")
 	@APIResponse(responseCode = "410", description = "Storage profile is archived")
-	public Response createBucket(@PathParam("vaultId") UUID vaultId, final CreateS3STSBucketDto storage) {
+	public Response createBucket(@PathParam("vaultId") UUID vaultId, @Valid @NotNull final CreateS3STSBucketDto storage) {
 		var storageProfileId = storage.storageConfigId();
 		var storageProfile = storageProfileRepo.findById(storageProfileId);
 		return switch (storageProfile) {
@@ -86,7 +80,7 @@ public class StorageResource {
 	@Operation(summary = "token exchange", description = "retrieves a downscoped access token for S3.")
 	@APIResponse(responseCode = "200", description = "success")
 	@APIResponse(responseCode = "400", description = "bad request")
-	public AccessTokenResponse exchangeS3Token(@QueryParam("vault") String vault) {
+	public AccessTokenResponse exchangeS3Token(@NotNull @QueryParam("vault") String vault) {
 		try {
 			return tokenExchangeApi.exchange("urn:ietf:params:oauth:grant-type:token-exchange",
 					jwt.getRawToken(),

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/package-info.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.cryptomator.hub.api.katta;
+
+import org.jspecify.annotations.NullMarked;

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/storage/S3StorageHelper.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/storage/S3StorageHelper.java
@@ -47,9 +47,7 @@ public class S3StorageHelper {
                             .pathStyleAccessEnabled(storageConfig.isPathStyleAccessEnabled())
                             .build());
         }
-        if (region != null) {
-            s3Builder = s3Builder.region(Region.of(region));
-        }
+        s3Builder = s3Builder.region(Region.of(region));
         try (final S3Client s3 = s3Builder.build()) {
             try {
                 s3.createBucket(CreateBucketRequest.builder()

--- a/backend/src/main/java/org/cryptomator/hub/api/katta/storage/package-info.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/katta/storage/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.cryptomator.hub.api.katta.storage;
+
+import org.jspecify.annotations.NullMarked;

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/AccessTokenResponse.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/AccessTokenResponse.java
@@ -1,6 +1,7 @@
 package org.cryptomator.hub.entities.katta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <a href="https://datatracker.ietf.org/doc/html/rfc8693#name-successful-response">RFC 8693 Token Exchange Response</a>.
@@ -19,8 +20,8 @@ public class AccessTokenResponse {
 	protected long expiresIn;
 
 	@JsonProperty("scope")
-	protected String scope;
+	protected @Nullable String scope;
 
 	@JsonProperty("refresh_token")
-	protected String refreshToken;
+	protected @Nullable String refreshToken;
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3STS.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3STS.java
@@ -35,6 +35,6 @@ public class StorageProfileS3STS extends StorageProfileS3Static {
 	@Column(name = "sts_duration_seconds")
 	public @Nullable Integer stsDurationSeconds;
 
-	@Column(name = "sts_session_tag")
-	public @Nullable String stsSessionTag;
+	@Column(name = "sts_session_tag", nullable = false)
+	public String stsSessionTag = "Vault";
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3STS.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3STS.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import org.jspecify.annotations.Nullable;
 
 @Entity
 @Table(name = "storage_profile_s3_sts")
@@ -20,7 +21,7 @@ public class StorageProfileS3STS extends StorageProfileS3Static {
 	public String stsRoleCreateBucketHub;
 
 	@Column(name = "sts_endpoint")
-	public String stsEndpoint = null;
+	public @Nullable String stsEndpoint;
 
 	//----------------------------------------------------------------------
 	// (3b) STS client profile custom properties
@@ -29,11 +30,11 @@ public class StorageProfileS3STS extends StorageProfileS3Static {
 	public String stsRoleAccessBucketAssumeRoleWithWebIdentity;
 
 	@Column(name = "sts_role_access_bucket_assume_role_tagged_session")
-	public String stsRoleAccessBucketAssumeRoleTaggedSession;
+	public @Nullable String stsRoleAccessBucketAssumeRoleTaggedSession;
 
 	@Column(name = "sts_duration_seconds")
-	public Integer stsDurationSeconds = null;
+	public @Nullable Integer stsDurationSeconds;
 
 	@Column(name = "sts_session_tag")
-	public String stsSessionTag;
+	public @Nullable String stsSessionTag;
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3Static.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3Static.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -23,10 +24,10 @@ public class StorageProfileS3Static extends StorageProfile {
 	// - client profile (STS and permanent)
 	//======================================================================
 	@Column(name = "endpoint")
-	public String endpoint;
+	public @Nullable String endpoint;
 
 	@Column(name = "path_style_access_enabled", nullable = false)
-	public Boolean pathStyleAccessEnabled = false;
+	public boolean pathStyleAccessEnabled = false;
 
 	@Column(name = "storage_class", columnDefinition = "storage_class", nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -35,10 +36,10 @@ public class StorageProfileS3Static extends StorageProfile {
 
 	// bucket creation parameters, relevant for both permanent and STS profiles (desktop client creates buckets in either case)
 	@Column(name = "region")
-	public String region;
+	public @Nullable String region;
 
 	@Column(name = "regions")
-	public List<String> regions;
+	public @Nullable List<String> regions;
 
 	@Column(name = "bucket_prefix", nullable = false)
 	public String bucketPrefix;

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3Static.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/StorageProfileS3Static.java
@@ -35,11 +35,11 @@ public class StorageProfileS3Static extends StorageProfile {
 	public S3StorageClass storageClass = S3StorageClass.STANDARD;
 
 	// bucket creation parameters, relevant for both permanent and STS profiles (desktop client creates buckets in either case)
-	@Column(name = "region")
-	public @Nullable String region;
+	@Column(name = "region", nullable = false)
+	public String region = "us-east-1";
 
-	@Column(name = "regions")
-	public @Nullable List<String> regions;
+	@Column(name = "regions", nullable = false)
+	public List<String> regions = List.of();
 
 	@Column(name = "bucket_prefix", nullable = false)
 	public String bucketPrefix;

--- a/backend/src/main/java/org/cryptomator/hub/entities/katta/package-info.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/katta/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.cryptomator.hub.entities.katta;
+
+import org.jspecify.annotations.NullMarked;

--- a/backend/src/main/java/org/cryptomator/hub/events/VaultMembersJoinedBroadcaster.java
+++ b/backend/src/main/java/org/cryptomator/hub/events/VaultMembersJoinedBroadcaster.java
@@ -3,6 +3,7 @@ package org.cryptomator.hub.events;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.TransactionPhase;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.Set;
@@ -23,7 +24,7 @@ import java.util.concurrent.TimeoutException;
 @ApplicationScoped
 public class VaultMembersJoinedBroadcaster {
 
-	private final Set<CompletableFuture<Void>> waiters = ConcurrentHashMap.newKeySet();
+	private final Set<CompletableFuture<@Nullable Void>> waiters = ConcurrentHashMap.newKeySet();
 
 	void onMembersJoined(@Observes(during = TransactionPhase.AFTER_SUCCESS) VaultMembersJoined event) {
 		for (var w : waiters) {
@@ -35,12 +36,12 @@ public class VaultMembersJoinedBroadcaster {
 	 * @return a {@link Ticket} that wakes on the next {@link VaultMembersJoined} fired after this call. Must be closed.
 	 */
 	public Ticket subscribe() {
-		var future = new CompletableFuture<Void>();
+		var future = new CompletableFuture<@Nullable Void>();
 		waiters.add(future);
 		return new Ticket(future, () -> waiters.remove(future));
 	}
 
-	public record Ticket(CompletableFuture<Void> future, Runnable cleanup) implements AutoCloseable {
+	public record Ticket(CompletableFuture<@Nullable Void> future, Runnable cleanup) implements AutoCloseable {
 
 		/**
 		 * Blocks the calling (virtual) thread until either an event fires or the timeout elapses. Swallows

--- a/backend/src/main/java/org/cryptomator/hub/events/package-info.java
+++ b/backend/src/main/java/org/cryptomator/hub/events/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.cryptomator.hub.events;
+
+import org.jspecify.annotations.NullMarked;

--- a/backend/src/main/java/org/cryptomator/hub/katta/KeycloakCryptomatorVaultsHelper.java
+++ b/backend/src/main/java/org/cryptomator/hub/katta/KeycloakCryptomatorVaultsHelper.java
@@ -8,6 +8,7 @@ import org.cryptomator.hub.entities.Vault;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
+import org.jspecify.annotations.Nullable;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientScopeResource;
@@ -35,7 +36,8 @@ public class KeycloakCryptomatorVaultsHelper {
 	@ConfigProperty(name = "hub.keycloak.realm")
 	protected String keycloakRealm;
 
-	public void keycloakPrepareVault(final String clientId, final String vaultId, final Boolean minio, final Boolean aws) {
+	// minio/aws are tri-state: true creates/updates the protocol mapper, false deletes it, null leaves it untouched
+	public void keycloakPrepareVault(final String clientId, final String vaultId, final @Nullable Boolean minio, final @Nullable Boolean aws) {
 		keycloakPrepareVault(clientId, vaultId, getKeycloak(), keycloakRealm, minio, aws);
 	}
 
@@ -77,7 +79,7 @@ public class KeycloakCryptomatorVaultsHelper {
 		}
 	}
 
-	protected static void keycloakPrepareVault(final String clientId, final String vaultId, final Keycloak keycloak, final String keycloakRealm, final Boolean minio, final Boolean aws) {
+	protected static void keycloakPrepareVault(final String clientId, final String vaultId, final Keycloak keycloak, final String keycloakRealm, final @Nullable Boolean minio, final @Nullable Boolean aws) {
 		// https://www.keycloak.org/docs-api/21.1.1/rest-api
 		final RealmResource realm = keycloak.realm(keycloakRealm);
 

--- a/backend/src/main/java/org/cryptomator/hub/katta/package-info.java
+++ b/backend/src/main/java/org/cryptomator/hub/katta/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.cryptomator.hub.katta;
+
+import org.jspecify.annotations.NullMarked;

--- a/backend/src/main/resources/org/cryptomator/hub/flyway/V101__StorageProfile.sql
+++ b/backend/src/main/resources/org/cryptomator/hub/flyway/V101__StorageProfile.sql
@@ -25,12 +25,12 @@ CREATE TABLE "storage_profile_s3_static"
 	"storage_class" storage_class NOT NULL,
 
 	-- bucket creation (desktop client), relevant for both permanent and STS profiles
-	"region"    VARCHAR,
-	"regions"   text[],
+	"region"    VARCHAR NOT NULL DEFAULT 'us-east-1',
+	"regions"   text[] NOT NULL DEFAULT '{}',
 	"bucket_prefix" VARCHAR NOT NULL,
 
 	CONSTRAINT "STORAGE_PROFILE_S3_STATIC_PK" PRIMARY KEY ("id"),
-	CONSTRAINT "STORAGE_PROFILE_S3_STATIC_FK" FOREIGN KEY ("id") REFERENCES "storage_profile" ("id") ON DELETE CASCADE
+	CONSTRAINT "STORAGE_PROFILE_S3_STATIC_FK" FOREIGN KEY ("id") REFERENCES "storage_profile" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE "storage_profile_s3_sts"
@@ -46,8 +46,8 @@ CREATE TABLE "storage_profile_s3_sts"
 	"sts_role_access_bucket_assume_role_with_web_identity" VARCHAR NOT NULL,
 	"sts_role_access_bucket_assume_role_tagged_session"   VARCHAR,
 	"sts_duration_seconds" INT4,
-	"sts_session_tag"      VARCHAR,
+	"sts_session_tag"      VARCHAR NOT NULL DEFAULT 'Vault',
 
 	CONSTRAINT "STORAGE_PROFILE_S3_STS_PK" PRIMARY KEY ("id"),
-	CONSTRAINT "STORAGE_PROFILE_S3_STS_FK" FOREIGN KEY ("id") REFERENCES "storage_profile_s3_static" ("id") ON DELETE CASCADE
+	CONSTRAINT "STORAGE_PROFILE_S3_STS_FK" FOREIGN KEY ("id") REFERENCES "storage_profile_s3_static" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -487,12 +487,14 @@ class VaultService {
 
   public async createOrUpdateVault(vault: VaultDto
     // / start katta extension
-    , aws: boolean | null = null
-    , minio: boolean | null = null
+    , aws?: boolean
+    , minio?: boolean
     // \ end katta extension
   ): Promise<VaultDto> {
     // / start katta modification
-    return axiosAuth.put(`/vaults/${vault.id}?aws=${aws}&minio=${minio}` , vault)
+    // aws/minio are tri-state: axios omits undefined params, which the backend reads as "leave the protocol mapper untouched".
+    // (String interpolation would send the literal "null"/"undefined", which the backend parses as false = delete the mapper.)
+    return axiosAuth.put(`/vaults/${vault.id}`, vault, { params: { aws, minio } })
     // \ end katta modification
       .then(response => response.data)
       .catch((error) => rethrowAndConvertIfExpected(error, 402, 404));

--- a/frontend/src/components/CreateVault.vue
+++ b/frontend/src/components/CreateVault.vue
@@ -732,7 +732,7 @@ const selectedRegion = ref<string>();
 const regions = ref<string[]>([]);
 const backends = ref<StorageProfileDto[]>([]);
 const storageProfilesLoaded = ref(false);
-const onFetchError = ref<Error | null>(null);
+const onFetchError = ref<Error>();
 const vaultAccessKeyId = ref('');
 const vaultSecretKey = ref('');
 const vaultBucketName = ref('');
@@ -741,8 +741,8 @@ const vaultBucketName = ref('');
 const bucketPrefix = computed(() => selectedStorageProfile.value?.bucketPrefix ?? '');
 const effectiveBucketName = computed(() => bucketPrefix.value + vaultBucketName.value);
 const automaticAccessGrant = ref<boolean>(true);
-const onOpenBookmarkError = ref<Error | null>(null);
-const onUploadTemplateError = ref<Error | null>(null);
+const onOpenBookmarkError = ref<Error>();
+const onUploadTemplateError = ref<Error>();
 
 class ErrorWithCodeHint extends Error {
 
@@ -1311,7 +1311,7 @@ async function downloadVaultTemplate() {
 // / start katta extension
 import { openInKatta } from '../common/deeplink';
 function openBookmark() {
-  onOpenBookmarkError.value = null;
+  onOpenBookmarkError.value = undefined;
   try {
     openInKatta();
   } catch (error) {
@@ -1321,7 +1321,7 @@ function openBookmark() {
 }
 
 async function fetchStorageProfiles() {
-  onFetchError.value = null;
+  onFetchError.value = undefined;
   storageProfilesLoaded.value = false;
   try {
     backends.value = await backend.storageprofiles.get(false);
@@ -1359,7 +1359,7 @@ function endpointHostname(endpoint: string | undefined): string | undefined {
 }
 
 async function uploadVaultTemplate() {
-  onUploadTemplateError.value = null;
+  onUploadTemplateError.value = undefined;
   try {
     const storageProfile = selectedStorageProfile.value;
     if (storageProfile === undefined) {

--- a/frontend/src/components/EditVaultMetadataDialog.vue
+++ b/frontend/src/components/EditVaultMetadataDialog.vue
@@ -115,7 +115,7 @@ async function updateVaultMetadata() {
     }
     const dto = { ...props.vault };
     dto.description = vaultDescription.value;
-    const updatedVault = await backend.vaults.createOrUpdateVault(dto, null, null);
+    const updatedVault = await backend.vaults.createOrUpdateVault(dto);
     emit('updated', updatedVault);
     open.value = false;
   } catch (error) {

--- a/frontend/src/components/katta/ArchiveStorageProfileDialog.vue
+++ b/frontend/src/components/katta/ArchiveStorageProfileDialog.vue
@@ -58,7 +58,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const open = ref(false);
 const processing = ref(false);
-const onArchiveError = ref<Error | null>();
+const onArchiveError = ref<Error>();
 
 const props = defineProps<{
   profile: StorageProfileDto
@@ -72,12 +72,12 @@ const emit = defineEmits<{
 defineExpose({ show });
 
 function show() {
-  onArchiveError.value = null;
+  onArchiveError.value = undefined;
   open.value = true;
 }
 
 async function archive() {
-  onArchiveError.value = null;
+  onArchiveError.value = undefined;
   processing.value = true;
   try {
     await backend.storageprofiles.setArchived(props.profile.id, true);

--- a/frontend/src/components/katta/CreateStorageProfileDialog.vue
+++ b/frontend/src/components/katta/CreateStorageProfileDialog.vue
@@ -147,7 +147,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const open = ref(false);
 const processing = ref(false);
-const onSubmitError = ref<Error | null>();
+const onSubmitError = ref<Error>();
 
 const protocols: StorageProtocol[] = ['S3STATIC', 'S3STS'];
 const storageClasses: S3StorageClass[] = ['STANDARD', 'INTELLIGENT_TIERING', 'STANDARD_IA', 'ONEZONE_IA', 'REDUCED_REDUNDANCY', 'GLACIER', 'GLACIER_IR', 'DEEP_ARCHIVE'];
@@ -164,7 +164,7 @@ type FormState = {
   stsEndpoint: string;
   stsRoleAccessBucketAssumeRoleWithWebIdentity: string;
   stsRoleAccessBucketAssumeRoleTaggedSession: string;
-  stsDurationSeconds: number | null;
+  stsDurationSeconds: number | undefined;
   stsSessionTag: string;
 };
 
@@ -192,7 +192,7 @@ function emptyState(): FormState {
     stsEndpoint: '',
     stsRoleAccessBucketAssumeRoleWithWebIdentity: '',
     stsRoleAccessBucketAssumeRoleTaggedSession: '',
-    stsDurationSeconds: null,
+    stsDurationSeconds: undefined,
     stsSessionTag: 'Vault'
   };
 }
@@ -201,7 +201,7 @@ function show() {
   protocol.value = 'S3STATIC';
   state.value = emptyState();
   regionsCsv.value = '';
-  onSubmitError.value = null;
+  onSubmitError.value = undefined;
   processing.value = false;
   open.value = true;
 }
@@ -271,13 +271,13 @@ function buildS3STSDto(endpoint: string | undefined): StorageProfileS3STSDto {
     stsEndpoint: undefinedIfBlank(state.value.stsEndpoint),
     stsRoleAccessBucketAssumeRoleWithWebIdentity: state.value.stsRoleAccessBucketAssumeRoleWithWebIdentity,
     stsRoleAccessBucketAssumeRoleTaggedSession: undefinedIfBlank(state.value.stsRoleAccessBucketAssumeRoleTaggedSession),
-    stsDurationSeconds: state.value.stsDurationSeconds ?? undefined,
+    stsDurationSeconds: state.value.stsDurationSeconds,
     stsSessionTag: state.value.stsSessionTag
   };
 }
 
 async function submit() {
-  onSubmitError.value = null;
+  onSubmitError.value = undefined;
   processing.value = true;
   try {
     const endpoint = validatedEndpoint(state.value.endpoint);

--- a/frontend/src/components/katta/PublicOnboarding.vue
+++ b/frontend/src/components/katta/PublicOnboarding.vue
@@ -101,14 +101,14 @@ const downloadAvailable = macUrl.length > 0 || winUrl.length > 0;
 const primaryOS = resolvePrimaryOS();
 const alternateOS = primaryOS === 'mac' && winUrl.length > 0 ? 'win'
   : primaryOS === 'win' && macUrl.length > 0 ? 'mac'
-    : null;
+    : undefined;
 const primaryHref = primaryOS === 'mac' ? macUrl : winUrl;
 const primaryLabelKey = `onboarding.download.${primaryOS}`;
 const alternateHref = alternateOS === 'mac' ? macUrl : winUrl;
 const alternateLabelKey = alternateOS === 'mac' ? 'onboarding.download.alternateMac' : 'onboarding.download.alternateWin';
 
 // Lead with the detected platform's build when its URL is configured, otherwise the single configured platform; both configured but no match falls through to two equal buttons.
-function resolvePrimaryOS(): 'mac' | 'win' | null {
+function resolvePrimaryOS(): 'mac' | 'win' | undefined {
   const detectedOS = detectOS();
   if (detectedOS === 'mac' && macUrl.length > 0) {
     return 'mac';
@@ -122,7 +122,7 @@ function resolvePrimaryOS(): 'mac' | 'win' | null {
   if (winUrl.length > 0 && macUrl.length === 0) {
     return 'win';
   }
-  return null;
+  return undefined;
 }
 
 function openBookmark() {

--- a/frontend/src/components/katta/ReactivateStorageProfileDialog.vue
+++ b/frontend/src/components/katta/ReactivateStorageProfileDialog.vue
@@ -58,7 +58,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const open = ref(false);
 const processing = ref(false);
-const onReactivateError = ref<Error | null>();
+const onReactivateError = ref<Error>();
 
 const props = defineProps<{
   profile: StorageProfileDto
@@ -72,12 +72,12 @@ const emit = defineEmits<{
 defineExpose({ show });
 
 function show() {
-  onReactivateError.value = null;
+  onReactivateError.value = undefined;
   open.value = true;
 }
 
 async function reactivate() {
-  onReactivateError.value = null;
+  onReactivateError.value = undefined;
   processing.value = true;
   try {
     await backend.storageprofiles.setArchived(props.profile.id, false);

--- a/frontend/src/components/katta/StorageProfiles.vue
+++ b/frontend/src/components/katta/StorageProfiles.vue
@@ -79,7 +79,7 @@
     <p class="mt-1 text-sm text-gray-500">{{ t('storageProfileList.filter.result.empty.description') }}</p>
   </div>
 
-  <SlideOver v-if="selectedStorageprofile != null" ref="StorageProfileDetailsSlideOver" :title="selectedStorageprofile.name" @close="selectedStorageprofile = null">
+  <SlideOver v-if="selectedStorageprofile != null" ref="StorageProfileDetailsSlideOver" :title="selectedStorageprofile.name" @close="selectedStorageprofile = undefined">
     <StorageProfileDetails :storageprofile-id="selectedStorageprofile.id" @storageprofile-updated="v => onSelectedStorageprofileUpdate(v)" />
   </SlideOver>
 
@@ -100,10 +100,10 @@ import StorageProfileDetails from './StorageProfileDetails.vue';
 const { t } = useI18n({ useScope: 'global' });
 
 const StorageProfileDetailsSlideOver = ref<typeof SlideOver>();
-const onFetchError = ref<Error | null>();
+const onFetchError = ref<Error>();
 
 const storageprofiles = ref<StorageProfileDto[]>();
-const selectedStorageprofile = ref<StorageProfileDto | null>(null);
+const selectedStorageprofile = ref<StorageProfileDto>();
 
 const isAdmin = ref<boolean>();
 
@@ -131,7 +131,7 @@ const filteredStorageprofiles = computed(() => {
 onMounted(fetchData);
 
 async function fetchData() {
-  onFetchError.value = null;
+  onFetchError.value = undefined;
   try {
     isAdmin.value = (await auth).hasRole('admin');
     storageprofiles.value = (await backend.storageprofiles.get(undefined));


### PR DESCRIPTION
references #65:

  ### Entities — mirror the column constraints in `V101__StorageProfile.sql`

  | Class | Field | Why null is possible |
  |---|---|---|
  | `StorageProfileS3Static` | `endpoint` | Column `endpoint` is nullable — unset means "use AWS SDK default endpoint" |
  | `StorageProfileS3Static` | `region` | Column `region` is nullable — unset means no default region preselected |
  | `StorageProfileS3Static` | `regions` | Column `regions` is nullable — unset means "full region list from AWS SDK" (`fromEntity` maps null → `List.of()`) |
  | `StorageProfileS3STS` | `stsEndpoint` | Column `sts_endpoint` is nullable — unset means AWS SDK default STS endpoint |
  | `StorageProfileS3STS` | `stsRoleAccessBucketAssumeRoleTaggedSession` | Column is nullable — role chaining is AWS-only, absent for MinIO |
  | `StorageProfileS3STS` | `stsDurationSeconds` | Column `sts_duration_seconds` is nullable — unset means AWS/MinIO default token lifetime (stays `Integer`, not `int`, for exactly this reason) |
  | `StorageProfileS3STS` | `stsSessionTag` | Column `sts_session_tag` is nullable in the DB (note: DTO declares it `@NotNull` — part of the known schema/DB mismatch) |
  | `AccessTokenResponse` | `scope`, `refreshToken` | Both OPTIONAL in an RFC 8693 token exchange response; Jackson leaves them null when absent |

  ### DTOs — match the wire contract (each already had `@Schema(nullable = true)` or is documented as server-assigned)

  | Class | Field / param | Why null is possible |
  |---|---|---|
  | `StorageProfileDto` | `id` (field, ctor param, `getId()`) | Server-assigned on creation; clients omit it on POST, so it's null during deserialization (schema: `readOnly`) |
  | `StorageProfileS3StaticDto` | `endpoint` (field, ctor param, `getEndpoint()`) | Optional per schema — unset means AWS SDK default endpoint |
  | `StorageProfileS3STSDto` | `stsEndpoint` (field, ctor param, getter) | Optional per schema — AWS SDK default |
  | `StorageProfileS3STSDto` | `stsRoleAccessBucketAssumeRoleTaggedSession` (field, ctor param, getter) | Optional per schema — AWS-only role chaining |
  | `StorageProfileS3STSDto` | `stsDurationSeconds` (field, ctor param, getter) | Optional per schema — provider default lifetime |
  | `CreateS3STSBucketDto` | `region` (record component) | `S3StorageHelper` explicitly branches on `region != null` (falls back to SDK default region / no location constraint) |

  ### Resource / helper parameters — tri-state semantics, null is meaningful

  | Location | Param | Why null is possible |
  |---|---|---|
  | `StorageProfileResource.getStorageProfiles` | `Boolean archived` | Tri-state filter: null = list all, true/false = filter by archived state (was `jakarta.annotation.Nullable`, now jspecify) |
  | `VaultResource.createOrUpdate` (katta block) | `Boolean minio`, `Boolean aws` | Optional query params — absent means null |
  | `KeycloakCryptomatorVaultsHelper.keycloakPrepareVault` (both overloads) | `Boolean minio`, `Boolean aws` | Tri-state: true = create/update protocol mapper, false = delete it, null = leave untouched (now documented at the
  declaration) |

  ### Type argument — JSpecify correctness under `@NullMarked`

  | Location | Type use | Why |
  |---|---|---|
  | `VaultMembersJoinedBroadcaster` | `CompletableFuture<@Nullable Void>` (field, `subscribe()`, `Ticket` component) | null is the only value of `Void`, and the code calls `complete(null)`; plain `Void` under `@NullMarked`
  would forbid that |